### PR TITLE
Replace dynamic asset generation with static files

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -1,0 +1,10 @@
+(function($){
+$(document).on("change", ".frcf-location-filter", function(){
+    var val = $(this).val();
+    var $cards = $(".frcf-course-card");
+    if(!val){ $cards.show(); return; }
+    $cards.hide().filter(function(){
+        return $(this).data("location") == val;
+    }).show();
+});
+})(jQuery);

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,84 @@
+/* FRCF Courses Styles */
+.frcf-courses-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+}
+.frcf-filter-container {
+    margin-bottom: 30px;
+    padding: 20px;
+    background: #f8f9fa;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+.frcf-filter-container label {
+    font-weight: 600;
+    color: #333;
+}
+.frcf-location-filter {
+    padding: 8px 15px;
+    border: 2px solid #e0e0e0;
+    border-radius: 5px;
+    font-size: 16px;
+    background: #fff;
+    cursor: pointer;
+    transition: border-color 0.3s;
+}
+.frcf-location-filter:hover,
+.frcf-location-filter:focus {
+    border-color: #e31e24;
+    outline: none;
+}
+.frcf-courses-grid {
+    display: grid;
+    gap: 30px;
+    margin-bottom: 40px;
+}
+.frcf-courses-grid.columns-2 { grid-template-columns: repeat(2, 1fr); }
+.frcf-courses-grid.columns-3 { grid-template-columns: repeat(3, 1fr); }
+.frcf-courses-grid.columns-4 { grid-template-columns: repeat(4, 1fr); }
+@media (max-width: 992px) {
+    .frcf-courses-grid.columns-4 { grid-template-columns: repeat(3, 1fr); }
+}
+@media (max-width: 768px) {
+    .frcf-courses-grid.columns-3,
+    .frcf-courses-grid.columns-4 { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 480px) {
+    .frcf-courses-grid.columns-2,
+    .frcf-courses-grid.columns-3,
+    .frcf-courses-grid.columns-4 { grid-template-columns: 1fr; }
+}
+.frcf-course-card {
+    background: #fff;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 4px 6px rgba(0,0,0,.1);
+    transition: transform .3s, box-shadow .3s;
+}
+.frcf-course-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 16px rgba(0,0,0,.12);
+}
+.frcf-course-image { aspect-ratio: 16/9; background: #f1f1f1; display: flex; align-items: center; justify-content: center; }
+.frcf-course-image img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.frcf-no-image .frcf-placeholder { width: 100%; height: 100%; display:flex; align-items:center; justify-content:center; font-weight:700; color:#e31e24; letter-spacing:1px; }
+.frcf-course-content { padding: 16px; }
+.frcf-course-title { margin: 0 0 8px; font-size: 1.1rem; line-height: 1.3; }
+.frcf-course-meta { display: grid; gap: 6px; margin-bottom: 10px; }
+.frcf-meta-item { display: flex; align-items: center; gap: 6px; font-size: .95rem; color: #333; }
+.frcf-course-description { color: #444; margin-bottom: 12px; }
+.frcf-course-action { display: flex; justify-content: flex-end; }
+.frcf-btn-register {
+    display: inline-block;
+    padding: 8px 14px;
+    border-radius: 8px;
+    background: #e31e24;
+    color: #fff;
+    text-decoration: none;
+    font-weight: 600;
+}
+.frcf-btn-register:hover { opacity: .9; }
+.frcf-no-courses { text-align:center; padding: 30px; background:#fafafa; border-radius:12px; }

--- a/frcf-course-manager.php
+++ b/frcf-course-manager.php
@@ -46,8 +46,6 @@ function frcf_courses_activate() {
 
     add_option('frcf_courses_db_version', FRCF_COURSES_VERSION);
 
-    // Creează assets dacă nu există
-    frcf_create_assets();
     flush_rewrite_rules();
 }
 
@@ -408,9 +406,6 @@ function frcf_courses_settings_page() {
 // ===== Frontend Assets =====
 add_action('wp_enqueue_scripts', 'frcf_courses_enqueue_scripts');
 function frcf_courses_enqueue_scripts() {
-    // dacă nu există încă, încearcă să le creezi
-    frcf_create_assets();
-
     wp_enqueue_style('frcf-courses-style', FRCF_COURSES_PLUGIN_URL . 'assets/style.css', array(), FRCF_COURSES_VERSION);
     wp_enqueue_script('frcf-courses-script', FRCF_COURSES_PLUGIN_URL . 'assets/script.js', array('jquery'), FRCF_COURSES_VERSION, true);
 
@@ -579,118 +574,3 @@ function frcf_courses_shortcode($atts) {
     return ob_get_clean();
 }
 
-// ===== Creare assets pe disc (style.css, script.js) =====
-function frcf_create_assets() {
-    $assets_dir = trailingslashit(FRCF_COURSES_PLUGIN_DIR . 'assets');
-
-    if (!file_exists($assets_dir)) {
-        wp_mkdir_p($assets_dir);
-    }
-
-    // CSS
-    $css_path = $assets_dir . 'style.css';
-    if (!file_exists($css_path)) {
-        $css_content = '/* FRCF Courses Styles */
-.frcf-courses-container {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 20px;
-}
-.frcf-filter-container {
-    margin-bottom: 30px;
-    padding: 20px;
-    background: #f8f9fa;
-    border-radius: 8px;
-    display: flex;
-    align-items: center;
-    gap: 15px;
-}
-.frcf-filter-container label {
-    font-weight: 600;
-    color: #333;
-}
-.frcf-location-filter {
-    padding: 8px 15px;
-    border: 2px solid #e0e0e0;
-    border-radius: 5px;
-    font-size: 16px;
-    background: #fff;
-    cursor: pointer;
-    transition: border-color 0.3s;
-}
-.frcf-location-filter:hover,
-.frcf-location-filter:focus {
-    border-color: #e31e24;
-    outline: none;
-}
-.frcf-courses-grid {
-    display: grid;
-    gap: 30px;
-    margin-bottom: 40px;
-}
-.frcf-courses-grid.columns-2 { grid-template-columns: repeat(2, 1fr); }
-.frcf-courses-grid.columns-3 { grid-template-columns: repeat(3, 1fr); }
-.frcf-courses-grid.columns-4 { grid-template-columns: repeat(4, 1fr); }
-@media (max-width: 992px) {
-    .frcf-courses-grid.columns-4 { grid-template-columns: repeat(3, 1fr); }
-}
-@media (max-width: 768px) {
-    .frcf-courses-grid.columns-3,
-    .frcf-courses-grid.columns-4 { grid-template-columns: repeat(2, 1fr); }
-}
-@media (max-width: 480px) {
-    .frcf-courses-grid.columns-2,
-    .frcf-courses-grid.columns-3,
-    .frcf-courses-grid.columns-4 { grid-template-columns: 1fr; }
-}
-.frcf-course-card {
-    background: #fff;
-    border-radius: 12px;
-    overflow: hidden;
-    box-shadow: 0 4px 6px rgba(0,0,0,.1);
-    transition: transform .3s, box-shadow .3s;
-}
-.frcf-course-card:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 8px 16px rgba(0,0,0,.12);
-}
-.frcf-course-image { aspect-ratio: 16/9; background: #f1f1f1; display: flex; align-items: center; justify-content: center; }
-.frcf-course-image img { width: 100%; height: 100%; object-fit: cover; display: block; }
-.frcf-no-image .frcf-placeholder { width: 100%; height: 100%; display:flex; align-items:center; justify-content:center; font-weight:700; color:#e31e24; letter-spacing:1px; }
-.frcf-course-content { padding: 16px; }
-.frcf-course-title { margin: 0 0 8px; font-size: 1.1rem; line-height: 1.3; }
-.frcf-course-meta { display: grid; gap: 6px; margin-bottom: 10px; }
-.frcf-meta-item { display: flex; align-items: center; gap: 6px; font-size: .95rem; color: #333; }
-.frcf-course-description { color: #444; margin-bottom: 12px; }
-.frcf-course-action { display: flex; justify-content: flex-end; }
-.frcf-btn-register {
-    display: inline-block;
-    padding: 8px 14px;
-    border-radius: 8px;
-    background: #e31e24;
-    color: #fff;
-    text-decoration: none;
-    font-weight: 600;
-}
-.frcf-btn-register:hover { opacity: .9; }
-.frcf-no-courses { text-align:center; padding: 30px; background:#fafafa; border-radius:12px; }
-';
-        file_put_contents($css_path, $css_content);
-    }
-
-    // JS
-    $js_path = $assets_dir . 'script.js';
-    if (!file_exists($js_path)) {
-        $js_content = '(function($){
-$(document).on("change", ".frcf-location-filter", function(){
-    var val = $(this).val();
-    var $cards = $(".frcf-course-card");
-    if(!val){ $cards.show(); return; }
-    $cards.hide().filter(function(){
-        return $(this).data("location") == val;
-    }).show();
-});
-})(jQuery);';
-        file_put_contents($js_path, $js_content);
-    }
-}


### PR DESCRIPTION
## Summary
- add prebuilt `assets/style.css` and `assets/script.js`
- remove `frcf_create_assets` and its activation/usage
- enqueue static assets directly

## Testing
- `php -l frcf-course-manager.php`


------
https://chatgpt.com/codex/tasks/task_e_68c16d1d5578832988f7cbcd4f53f755