### PR TITLE
Fix course visibility using WordPress timezone

### DIFF
--- a/public/shortcode.php
+++ b/public/shortcode.php
@@ -27,7 +27,7 @@ function frcf_courses_shortcode($atts) {
         'debug'    => 'no'
     ), $atts, 'frcf_courses');
 
-    $today = date('Y-m-d');
+    $today = current_time('Y-m-d');
 
     // Construim query
     if ($atts['show_all'] === 'yes') {


### PR DESCRIPTION
## Summary
- Use WordPress's `current_time` instead of PHP `date` when filtering courses, ensuring date comparisons respect the site's timezone.

## Testing
- `php -l frcf-course-manager.php`
- `php -l public/shortcode.php`
- `php -l admin/admin-pages.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1702a09d88329980ff8d75f2f1c28