### PR TITLE
Add admin management for organizers, locations and internal categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FRCF Course Manager
 
-Modul WordPress pentru gestionarea și afișarea cursurilor FRCF. Permite adăugarea manuală a cursurilor în panoul de administrare, filtrarea după locație și ascunderea automată a evenimentelor expirate.
+Modul WordPress pentru gestionarea și afișarea cursurilor FRCF. Permite adăugarea manuală a cursurilor în panoul de administrare, gestionarea organizatorilor, locațiilor și categoriilor (categoriile nu sunt afișate public), filtrarea după locație și ascunderea automată a evenimentelor expirate.
 
 ## Instalare
 
@@ -14,6 +14,7 @@ Modul WordPress pentru gestionarea și afișarea cursurilor FRCF. Permite adăug
 
 - adăuga, edita sau șterge cursuri;
 - ajusta numărul de coloane și cursuri pe pagină din **FRCF Cursuri → Setări**.
+- gestiona organizatorii, locațiile și categoriile cursurilor.
 
 ## Shortcode
 

--- a/frcf-course-manager.php
+++ b/frcf-course-manager.php
@@ -33,12 +33,14 @@ function frcf_courses_activate() {
         start_date date NOT NULL,
         end_date date,
         organizer varchar(255),
+        category varchar(255),
         description longtext,
         created_at datetime DEFAULT CURRENT_TIMESTAMP,
         PRIMARY KEY  (id),
         KEY start_date (start_date),
         KEY end_date (end_date),
-        KEY location (location)
+        KEY location (location),
+        KEY category (category)
     ) $charset_collate;";
 
     require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
@@ -52,6 +54,17 @@ function frcf_courses_activate() {
 register_deactivation_hook(__FILE__, 'frcf_courses_deactivate');
 function frcf_courses_deactivate() {
     flush_rewrite_rules();
+}
+
+// Ensure database schema is up to date
+add_action('plugins_loaded', 'frcf_courses_maybe_upgrade');
+function frcf_courses_maybe_upgrade() {
+    global $wpdb;
+    $table = FRCF_COURSES_TABLE;
+    $column = $wpdb->get_results( $wpdb->prepare("SHOW COLUMNS FROM $table LIKE %s", 'category') );
+    if ( empty( $column ) ) {
+        $wpdb->query("ALTER TABLE $table ADD category varchar(255) AFTER organizer, ADD KEY category (category)");
+    }
 }
 
 

--- a/public/shortcode.php
+++ b/public/shortcode.php
@@ -62,8 +62,7 @@ class Frcf_Courses_Shortcode {
             $sql .= ' WHERE ' . implode( ' AND ', $where_conditions );
         }
 
-        $order = $args['show_all'] ? 'DESC' : 'ASC';
-        $sql  .= " ORDER BY start_date $order";
+        $sql .= ' ORDER BY start_date ASC';
 
         $sql            .= ' LIMIT %d';
         $prepare_values[] = $args['limit'];


### PR DESCRIPTION
## Summary
- allow managing organizers, locations and internal-only categories
- add category field to course data and admin interface
- sort public courses from oldest to newest

## Testing
- `php -l frcf-course-manager.php`
- `php -l admin/admin-pages.php`
- `php -l public/shortcode.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1a38ffd308329ad9a5a73fb787748