### PR TITLE
Document all shortcodes and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Modul WordPress pentru gestionarea și afișarea cursurilor FRCF. Permite adăug
 - ajusta numărul de coloane și cursuri pe pagină din **FRCF Cursuri → Setări**.
 - gestiona organizatorii, locațiile și categoriile cursurilor.
 
-## Shortcode
+## Shortcodes
+
+### `[frcf_courses]`
 
 Folosește shortcode-ul `[frcf_courses]` pentru a afișa lista de cursuri.
-
-Shortcode-ul `[frcf_courses_by_category]` afișează cursurile grupate și sortate după categorie.
 
 Exemple:
 
@@ -29,7 +29,7 @@ Exemple:
 [frcf_courses columns="4"]
 [frcf_courses location="București" limit="5"]
 [frcf_courses show_all="yes"]
-[frcf_courses_by_category]
+[frcf_courses debug="yes"]
 ```
 
 Atribute disponibile:
@@ -39,6 +39,28 @@ Atribute disponibile:
 - `limit` – numărul maxim de cursuri returnate.
 - `show_all` – `yes` pentru a afișa și cursurile expirate.
 - `debug` – `yes` afișează informații de depanare.
+
+### `[frcf_courses_by_category]`
+
+Shortcode-ul `[frcf_courses_by_category]` afișează cursurile grupate și sortate după categorie.
+
+Exemple:
+
+```
+[frcf_courses_by_category]
+[frcf_courses_by_category columns="4"]
+[frcf_courses_by_category location="București" limit="5"]
+[frcf_courses_by_category show_all="yes"]
+```
+
+Atribute disponibile:
+
+- `columns` – numărul de coloane (2–4).
+- `location` – afișează doar cursurile dintr-o anumită locație.
+- `limit` – numărul maxim de cursuri returnate.
+- `show_all` – `yes` pentru a afișa și cursurile expirate.
+
+Instrucțiunile pentru aceste shortcode-uri sunt disponibile și în pagina de setări a modulului.
 
 ## Licență
 

--- a/admin/admin-pages.php
+++ b/admin/admin-pages.php
@@ -448,6 +448,13 @@ function frcf_courses_settings_page() {
             <li><code>[frcf_courses show_all="yes"]</code> – <?php echo esc_html__( 'Afișează toate cursurile (inclusiv expirate)', 'frcf-courses' ); ?></li>
             <li><code>[frcf_courses debug="yes"]</code> – <?php echo esc_html__( 'Afișează informații de debug', 'frcf-courses' ); ?></li>
         </ul>
+        <p><?php echo esc_html__( 'Shortcode-ul', 'frcf-courses' ); ?> <code>[frcf_courses_by_category]</code> <?php echo esc_html__( 'afișează cursurile grupate și sortate după categorie.', 'frcf-courses' ); ?></p>
+        <ul>
+            <li><code>[frcf_courses_by_category columns="3"]</code> – <?php echo esc_html__( 'Setează numărul de coloane', 'frcf-courses' ); ?></li>
+            <li><code>[frcf_courses_by_category location="București"]</code> – <?php echo esc_html__( 'Afișează doar cursurile dintr-o locație', 'frcf-courses' ); ?></li>
+            <li><code>[frcf_courses_by_category limit="6"]</code> – <?php echo esc_html__( 'Limitează numărul de cursuri', 'frcf-courses' ); ?></li>
+            <li><code>[frcf_courses_by_category show_all="yes"]</code> – <?php echo esc_html__( 'Afișează toate cursurile (inclusiv expirate)', 'frcf-courses' ); ?></li>
+        </ul>
     </div>
     <?php
 }


### PR DESCRIPTION
## Summary
- Show instructions for `[frcf_courses_by_category]` in plugin settings
- Expand README with examples and attributes for both shortcodes

## Testing
- `php -l admin/admin-pages.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1b3d03afc83298f27e1002a929747