### PR TITLE
Add category filter to course shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Atribute disponibile:
 
 - `columns` – numărul de coloane (2–4).
 - `location` – afișează doar cursurile dintr-o anumită locație.
+- `category` / `categorie` – afișează doar cursurile dintr-o anumită categorie.
 - `limit` – numărul maxim de cursuri returnate.
 - `show_all` – `yes` pentru a afișa și cursurile expirate.
 - `debug` – `yes` afișează informații de depanare.

--- a/public/shortcode.php
+++ b/public/shortcode.php
@@ -50,6 +50,11 @@ class Frcf_Courses_Shortcode {
             $prepare_values[]   = $args['location'];
         }
 
+        if ( ! empty( $args['category'] ) ) {
+            $where_conditions[] = 'category = %s';
+            $prepare_values[]   = $args['category'];
+        }
+
         if ( ! $args['show_all'] ) {
             // Include courses that start in the future or are still in progress.
 
@@ -83,6 +88,8 @@ class Frcf_Courses_Shortcode {
             array(
                 'columns'  => get_option( 'frcf_courses_columns', 3 ),
                 'location' => '',
+                'category' => '',
+                'categorie' => '',
                 'limit'    => get_option( 'frcf_courses_per_page', 12 ),
                 'show_all' => 'no',
                 'debug'    => 'no',
@@ -94,6 +101,7 @@ class Frcf_Courses_Shortcode {
         $args = array(
             'columns'  => max( 2, min( 4, (int) $atts['columns'] ) ),
             'location' => sanitize_text_field( $atts['location'] ),
+            'category' => sanitize_text_field( $atts['category'] ? $atts['category'] : $atts['categorie'] ),
             'limit'    => max( 1, (int) $atts['limit'] ),
             'show_all' => in_array( strtolower( $atts['show_all'] ), array( '1', 'true', 'yes' ), true ),
             'debug'    => in_array( strtolower( $atts['debug'] ), array( '1', 'true', 'yes' ), true ),


### PR DESCRIPTION
## Summary
- allow filtering courses by category in `[frcf_courses]` shortcode
- document category filter option in README

## Testing
- `php -l public/shortcode.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1b57c95ac8329b09334a4746a6a95